### PR TITLE
Implement GitHub Actions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run:
-    runs-on: debian-bullseye
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -22,15 +22,10 @@ jobs:
       - name: Update and install system dependencies
         run: |
           apt-get update
-          apt-get upgrade
           apt-get install -y \
             nginx \
             openssl \
             dos2unix
-
-      - name: Change ownership of /opt/improved_intra_server
-        run: |
-          chown -R www-data:www-data /opt/improved_intra_server
 
       - name: Install PostgreSQL dependencies
         run: |
@@ -64,6 +59,7 @@ jobs:
           apt-get install -y \
             python3 \
             python3-pip \
+            python3-dev \
             python-setuptools \
             libpq-dev \
             python3-virtualenv \
@@ -73,19 +69,12 @@ jobs:
         working-directory: /opt/improved_intra_server
         run: |
           virtualenv -p python3 .venv
-          chown -R www-data:www-data /opt/improved_intra_server
 
       - name: Install Python dependencies
         working-directory: /opt/improved_intra_server
         run: |
           source .venv/bin/activate
           .venv/bin/pip install -r requirements.txt
-
-      - name: Set up secrets
-        working-directory: /opt/improved_intra_server
-        run: |
-          cp .secret.env.example .secret.env
-          chown -R www-data:www-data .secret.env
 
       - name: Set up nginx as reverse-proxy
         working-directory: /opt/improved_intra_server
@@ -121,7 +110,8 @@ jobs:
         run: |
           dos2unix /opt/improved_intra_server/gunicorn.sh
           mkdir -p /opt/improved_intra_server/logs
-          chown -R www-data:www-data /opt/improved_intra_server/logs
+          cp .secret.env.example .secret.env
+          chown -R www-data:www-data /opt/improved_intra_server
 
       - name: Start Improved Intra server
         working-directory: /opt/improved_intra_server

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ '*' ]
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -11,101 +11,123 @@ on:
 jobs:
   run:
     runs-on: debian-bullseye
+
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: /opt/improved_intra_server
-          submodules: recursive
-          set-safe-directory: true
+
+      - name: Link /opt/improved_intra_server to the repository
+        run: |
+          ln -s $GITHUB_WORKSPACE /opt/improved_intra_server
 
       - name: Update and install system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get upgrade
-          sudo apt-get install -y \
+          apt-get update
+          apt-get upgrade
+          apt-get install -y \
             nginx \
-            openssl
+            openssl \
+            dos2unix
 
       - name: Change ownership of /opt/improved_intra_server
         run: |
-          sudo chown -R www-data:www-data /opt/improved_intra_server
+          chown -R www-data:www-data /opt/improved_intra_server
 
       - name: Install PostgreSQL dependencies
         run: |
-          sudo apt-get install -y \
+          apt-get install -y \
             wget \
             lsb-release \
             gnupg2
 
       - name: Add PostgreSQL repository
         run: |
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
       - name: Install PostgresQL
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          apt-get update
+          apt-get install -y \
           postgresql
 
       - name: Start PostgreSQL
         run: |
-          sudo service postgresql start
+          service postgresql start
 
       - name: Set up PostgreSQL
         run: |
-          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-          sudo -u postgres psql -c "CREATE DATABASE "iintra" WITH OWNER "postgres" ENCODING 'UTF8';"
+          su - postgres -c "psql -c \"ALTER USER postgres PASSWORD 'postgres';\""
+          su - postgres -c "psql -c \"CREATE DATABASE \\\"iintra\\\" WITH OWNER \\\"postgres\\\" ENCODING 'UTF8';\""
 
       - name: Install Python3
         run: |
-          sudo apt-get install -y \
+          apt-get install -y \
             python3 \
             python3-pip \
             python-setuptools \
             libpq-dev \
-            python3-virtualenv
+            python3-virtualenv \
             virtualenv
 
       - name: Initialize the virtual environment
         working-directory: /opt/improved_intra_server
         run: |
-          sudo virtualenv -p python3 .venv
-          sudo chown -R www-data:www-data /opt/improved_intra_server
+          virtualenv -p python3 .venv
+          chown -R www-data:www-data /opt/improved_intra_server
 
       - name: Install Python dependencies
         working-directory: /opt/improved_intra_server
         run: |
           source .venv/bin/activate
-          sudo .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -r requirements.txt
 
       - name: Set up secrets
         working-directory: /opt/improved_intra_server
         run: |
-          sudo cp .secret.env.example .secret.env
-          sudo chown -R www-data:www-data .secret.env
+          cp .secret.env.example .secret.env
+          chown -R www-data:www-data .secret.env
 
       - name: Start Improved Intra server
-        working-directory: /opt/improved_intra_server
         run: |
-          sudo cp ./useful/iintra-server.service /etc/systemd/system/iintra-server.service
-          sudo systemctl daemon-reload
-          sudo systemctl start iintra-server.service
+          dos2unix /opt/improved_intra_server/gunicorn.sh
+          mkdir -p /opt/improved_intra_server/logs
+          chown -R www-data:www-data /opt/improved_intra_server/logs
+          bash /opt/improved_intra_server/gunicorn.sh &
 
       - name: Set up nginx as reverse-proxy
         working-directory: /opt/improved_intra_server
         run: |
-          sudo cp ./useful/*.nginx.snippet.conf /etc/nginx/snippets/
-          sudo rm -f /etc/nginx/sites-enabled/default
-          sudo mkdir -p /etc/nginx/ssl
-          sudo openssl req -newkey rsa:2048 -x509 -days 365 -nodes \
+          cp ./useful/*.nginx.snippet.conf /etc/nginx/snippets/
+          rm -f /etc/nginx/sites-enabled/default
+          mkdir -p /etc/nginx/ssl
+          openssl req -newkey rsa:2048 -x509 -days 365 -nodes \
             -keyout /etc/nginx/ssl/server.key -out /etc/nginx/ssl/server.pem \
-            -subj "/C=NL/ST=North-Holland/L=Amsterdam/O=ImprovedIntra/CN=iintra.freekb.es/
-          sudo cp ./useful/nginx.example.ssl.conf /etc/nginx/sites-available/iintra.freekb.es.conf
-          sudo ln -s /etc/nginx/sites-available/iintra.freekb.es.conf /etc/nginx/sites-enabled/iintra.freekb.es.conf
-          sudo nginx -t
-          sudo systemctl restart nginx
+            -subj "/C=NL/ST=North-Holland/L=Amsterdam/O=ImprovedIntra/CN=iintra.freekb.es/"
+          cp ./useful/nginx.example.ssl.conf /etc/nginx/sites-available/iintra.freekb.es.conf
+          ln -s /etc/nginx/sites-available/iintra.freekb.es.conf /etc/nginx/sites-enabled/iintra.freekb.es.conf
+
+      - name: Wait for the gunicorn server to start
+        run: |
+          sleep 30
+
+      - name: Test nginx configuration
+        run: |
+          cat /etc/nginx/sites-available/iintra.freekb.es.conf
+          cat /etc/nginx/snippets/*.nginx.snippet.conf
+          nginx -t
+
+      - name: Reload nginx
+        run: |
+          /etc/init.d/nginx reload
+          sleep 5
+
+      - name: Install testing dependencies
+        run: |
+          apt-get install -y \
+            curl \
+            net-tools
 
       - name: Curl the server
         run: |
+          netstat -tulpn
           curl -L https://iintra.freekb.es/ --insecure --verbose --resolve 'iintra.freekb.es:443:127.0.0.1' --fail

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -87,13 +87,6 @@ jobs:
           cp .secret.env.example .secret.env
           chown -R www-data:www-data .secret.env
 
-      - name: Start Improved Intra server
-        run: |
-          dos2unix /opt/improved_intra_server/gunicorn.sh
-          mkdir -p /opt/improved_intra_server/logs
-          chown -R www-data:www-data /opt/improved_intra_server/logs
-          bash /opt/improved_intra_server/gunicorn.sh &
-
       - name: Set up nginx as reverse-proxy
         working-directory: /opt/improved_intra_server
         run: |
@@ -106,28 +99,44 @@ jobs:
           cp ./useful/nginx.example.ssl.conf /etc/nginx/sites-available/iintra.freekb.es.conf
           ln -s /etc/nginx/sites-available/iintra.freekb.es.conf /etc/nginx/sites-enabled/iintra.freekb.es.conf
 
-      - name: Wait for the gunicorn server to start
-        run: |
-          sleep 30
-
       - name: Test nginx configuration
         run: |
           cat /etc/nginx/sites-available/iintra.freekb.es.conf
           cat /etc/nginx/snippets/*.nginx.snippet.conf
           nginx -t
 
-      - name: Reload nginx
+      - name: Restart nginx
         run: |
-          /etc/init.d/nginx reload
-          sleep 5
+          /etc/init.d/nginx restart
 
       - name: Install testing dependencies
         run: |
           apt-get install -y \
             curl \
-            net-tools
+            net-tools \
+            netcat
 
-      - name: Curl the server
+      - name: Prepare for Improved Intra server start
+        working-directory: /opt/improved_intra_server
         run: |
+          dos2unix /opt/improved_intra_server/gunicorn.sh
+          mkdir -p /opt/improved_intra_server/logs
+          chown -R www-data:www-data /opt/improved_intra_server/logs
+
+      - name: Start Improved Intra server
+        working-directory: /opt/improved_intra_server
+        shell: bash
+        run: |
+          bash /opt/improved_intra_server/gunicorn.sh &
+          timeout 3m bash -c 'until nc -w 10 127.0.0.1 8000; do sleep 1; done'
           netstat -tulpn
+          curl -L http://localhost:8000/ --insecure --verbose --fail
           curl -L https://iintra.freekb.es/ --insecure --verbose --resolve 'iintra.freekb.es:443:127.0.0.1' --fail
+
+      - name: Print logs
+        if: always()
+        working-directory: /opt/improved_intra_server
+        run: |
+          cat /opt/improved_intra_server/logs/server.log || true
+          cat /opt/improved_intra_server/logs/error.log || true
+          cat /opt/improved_intra_server/logs/access.log || true

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -21,42 +21,42 @@ jobs:
 
       - name: Update and install system dependencies
         run: |
-          apt-get update
-          apt-get install -y \
+          sudo apt-get update
+          sudo apt-get install -y \
             nginx \
             openssl \
             dos2unix
 
       - name: Install PostgreSQL dependencies
         run: |
-          apt-get install -y \
+          sudo apt-get install -y \
             wget \
             lsb-release \
             gnupg2
 
       - name: Add PostgreSQL repository
         run: |
-          sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
       - name: Install PostgresQL
         run: |
-          apt-get update
-          apt-get install -y \
+          sudo apt-get update
+          sudo apt-get install -y \
           postgresql
 
       - name: Start PostgreSQL
         run: |
-          service postgresql start
+          sudo service postgresql start
 
       - name: Set up PostgreSQL
         run: |
-          su - postgres -c "psql -c \"ALTER USER postgres PASSWORD 'postgres';\""
-          su - postgres -c "psql -c \"CREATE DATABASE \\\"iintra\\\" WITH OWNER \\\"postgres\\\" ENCODING 'UTF8';\""
+          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+          sudo -u postgres psql -c "CREATE DATABASE \"iintra\" WITH OWNER \"postgres\" ENCODING 'UTF8';"
 
       - name: Install Python3
         run: |
-          apt-get install -y \
+          sudo apt-get install -y \
             python3 \
             python3-pip \
             python3-dev \
@@ -79,14 +79,14 @@ jobs:
       - name: Set up nginx as reverse-proxy
         working-directory: /opt/improved_intra_server
         run: |
-          cp ./useful/*.nginx.snippet.conf /etc/nginx/snippets/
-          rm -f /etc/nginx/sites-enabled/default
-          mkdir -p /etc/nginx/ssl
-          openssl req -newkey rsa:2048 -x509 -days 365 -nodes \
+          sudo cp ./useful/*.nginx.snippet.conf /etc/nginx/snippets/
+          sudo rm -f /etc/nginx/sites-enabled/default
+          sudo mkdir -p /etc/nginx/ssl
+          sudo openssl req -newkey rsa:2048 -x509 -days 365 -nodes \
             -keyout /etc/nginx/ssl/server.key -out /etc/nginx/ssl/server.pem \
             -subj "/C=NL/ST=North-Holland/L=Amsterdam/O=ImprovedIntra/CN=iintra.freekb.es/"
-          cp ./useful/nginx.example.ssl.conf /etc/nginx/sites-available/iintra.freekb.es.conf
-          ln -s /etc/nginx/sites-available/iintra.freekb.es.conf /etc/nginx/sites-enabled/iintra.freekb.es.conf
+          sudo cp ./useful/nginx.example.ssl.conf /etc/nginx/sites-available/iintra.freekb.es.conf
+          sudo ln -s /etc/nginx/sites-available/iintra.freekb.es.conf /etc/nginx/sites-enabled/iintra.freekb.es.conf
 
       - name: Test nginx configuration
         run: |
@@ -96,11 +96,11 @@ jobs:
 
       - name: Restart nginx
         run: |
-          /etc/init.d/nginx restart
+          sudo /etc/init.d/nginx restart
 
       - name: Install testing dependencies
         run: |
-          apt-get install -y \
+          sudo apt-get install -y \
             curl \
             net-tools \
             netcat
@@ -111,7 +111,7 @@ jobs:
           dos2unix /opt/improved_intra_server/gunicorn.sh
           mkdir -p /opt/improved_intra_server/logs
           cp .secret.env.example .secret.env
-          chown -R www-data:www-data /opt/improved_intra_server
+          sudo chown -R www-data:www-data /opt/improved_intra_server
 
       - name: Start Improved Intra server
         working-directory: /opt/improved_intra_server

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,110 @@
+name: Run Improved Intra Server
+
+on:
+  push:
+    branches: [ main, github-actions ]
+  pull_request:
+    branches: [ '*' ]
+  workflow_call:
+
+jobs:
+  run:
+    runs-on: debian-bullseye
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: /opt/improved_intra_server
+          submodules: recursive
+          set-safe-directory: true
+
+      - name: Update and install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade
+          sudo apt-get install -y \
+            nginx \
+            openssl
+
+      - name: Change ownership of /opt/improved_intra_server
+        run: |
+          sudo chown -R www-data:www-data /opt/improved_intra_server
+
+      - name: Install PostgreSQL dependencies
+        run: |
+          sudo apt-get install -y \
+            wget \
+            lsb-release \
+            gnupg2
+
+      - name: Add PostgreSQL repository
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+
+      - name: Install PostgresQL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+          postgresql
+
+      - name: Start PostgreSQL
+        run: |
+          sudo service postgresql start
+
+      - name: Set up PostgreSQL
+        run: |
+          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+          sudo -u postgres psql -c "CREATE DATABASE "iintra" WITH OWNER "postgres" ENCODING 'UTF8';"
+
+      - name: Install Python3
+        run: |
+          sudo apt-get install -y \
+            python3 \
+            python3-pip \
+            python-setuptools \
+            libpq-dev \
+            python3-virtualenv
+            virtualenv
+
+      - name: Initialize the virtual environment
+        working-directory: /opt/improved_intra_server
+        run: |
+          sudo virtualenv -p python3 .venv
+          sudo chown -R www-data:www-data /opt/improved_intra_server
+
+      - name: Install Python dependencies
+        working-directory: /opt/improved_intra_server
+        run: |
+          source .venv/bin/activate
+          sudo .venv/bin/pip install -r requirements.txt
+
+      - name: Set up secrets
+        working-directory: /opt/improved_intra_server
+        run: |
+          sudo cp .secret.env.example .secret.env
+          sudo chown -R www-data:www-data .secret.env
+
+      - name: Start Improved Intra server
+        working-directory: /opt/improved_intra_server
+        run: |
+          sudo cp ./useful/iintra-server.service /etc/systemd/system/iintra-server.service
+          sudo systemctl daemon-reload
+          sudo systemctl start iintra-server.service
+
+      - name: Set up nginx as reverse-proxy
+        working-directory: /opt/improved_intra_server
+        run: |
+          sudo cp ./useful/*.nginx.snippet.conf /etc/nginx/snippets/
+          sudo rm -f /etc/nginx/sites-enabled/default
+          sudo mkdir -p /etc/nginx/ssl
+          sudo openssl req -newkey rsa:2048 -x509 -days 365 -nodes \
+            -keyout /etc/nginx/ssl/server.key -out /etc/nginx/ssl/server.pem \
+            -subj "/C=NL/ST=North-Holland/L=Amsterdam/O=ImprovedIntra/CN=iintra.freekb.es/
+          sudo cp ./useful/nginx.example.ssl.conf /etc/nginx/sites-available/iintra.freekb.es.conf
+          sudo ln -s /etc/nginx/sites-available/iintra.freekb.es.conf /etc/nginx/sites-enabled/iintra.freekb.es.conf
+          sudo nginx -t
+          sudo systemctl restart nginx
+
+      - name: Curl the server
+        run: |
+          curl -L https://iintra.freekb.es/ --insecure --verbose --resolve 'iintra.freekb.es:443:127.0.0.1' --fail

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           cat /etc/nginx/sites-available/iintra.freekb.es.conf
           cat /etc/nginx/snippets/*.nginx.snippet.conf
-          nginx -t
+          sudo nginx -t
 
       - name: Restart nginx
         run: |


### PR DESCRIPTION
This pull request implements an action for GitHub Actions.

It does run under Ubuntu, not under Debian like the readme describes. The reason for this is that Debian is unavailable as a runner image in GitHub Actions.

The action will need to be updated when the [docker](https://github.com/FreekBes/improved_intra_server/tree/docker) branch is merged. Perhaps the Docker image can be changed to run under Ubuntu as well.